### PR TITLE
Add support for laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/support": "^10.0|^11.0|^12"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
This simple PR adds support for laravel 12 application by adding version 12 to the supported versions of lluminate/support.